### PR TITLE
Simplify template rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "nickel 0.1.0 (git+https://github.com/nickel-org/nickel.rs.git)",
  "nickel_macros 0.0.1 (git+https://github.com/nickel-org/nickel.rs.git)",
  "rust-mustache 0.3.0 (git+https://github.com/nickel-org/rust-mustache.git)",
+ "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ path = "nickel_macros"
 
 [dependencies.rust-mustache]
 git = "https://github.com/nickel-org/rust-mustache.git"
+
+[dependencies]
+rustc-serialize = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,28 @@
 #![feature(net)]
-#![feature(path)]
-#![feature(fs)]
-#![feature(io)]
-
 extern crate nickel;
 #[macro_use] extern crate nickel_macros;
 extern crate mustache;
+extern crate "rustc-serialize" as rustc_serialize;
 
 use std::collections::HashMap;
 use std::net::IpAddr;
 use nickel::*;
-use std::path::PathBuf;
-use std::fs::File;
-use std::io::Read;
-use mustache::*;
+// use mustache::*;
+use rustc_serialize::Encodable;
+
+
+struct View<T>(&'static str, T);
+
+impl<T: Encodable> ResponseFinalizer for View<T> {
+    fn respond<'a>(self, res: Response<'a>) -> MiddlewareResult<'a> {
+        let View(path, data) = self;
+        let stream = try!(res.render(path, &data));
+
+        Ok(Halt(stream))
+    }
+}
 
 fn main() {
-
    let mut nickel = Nickel::new();
 
    nickel.utilize(StaticFilesHandler::new("public/"));
@@ -29,26 +35,11 @@ fn main() {
 
    get "**" => |request, response| {
       let mut data = HashMap::new();
-      data.insert("title".to_string(), StrVal("nickel-bootstrap".to_string()));
-      data.insert("message".to_string(), StrVal("Welcome to".to_string()));
-      data.insert("message_line_two".to_string(), StrVal("You can edit this to get started...".to_string()));
+      data.insert("title", "nickel-bootstrap");
+      data.insert("message", "Welcome to");
+      data.insert("message_line_two", "You can edit this to get started...");
 
-      let template_file = "templates/all_for_one.mustache";
-
-      let mut file = File::open(&PathBuf::new(template_file))
-                          .ok()
-                          .expect(&*format!("Couldn't open template: {}", template_file));
-
-      let mut raw_template = String::new();
-      file.read_to_string(&mut raw_template)
-          .ok()
-          .expect(&*format!("Couldn't read template file: {}", template_file));
-
-      let template = mustache::compile_str(&*raw_template);
-
-      let mut resp = vec![];
-      template.render_data(&mut resp, &Map(data));
-      String::from_utf8(resp).unwrap()
+      View("templates/all_for_one.mustache", data)
    }
 
    ));


### PR DESCRIPTION
The struct introduced in this will probably be added to nickel core soon enough, it should be more generic in the paths that it stores though! 

To address some readme comments:
- Yes, listing cargo requirements in readme is definitely a todo
- default 'resource' folders, not sure, we probably have to have a discussion around project scope regarding the `express.js` inspiration
- I checked partials and still not working 
- The images loaded fine for me?
- `Ok(Halt(resp...))` - I think that doesnt work with macros atm still due to how things are with the move to hyper and ownership (cant impl finalizer for middlewareresult 
  - not sure about your closure comment here, the macro is not a closure currently
- we use utilise as use is a keyword, welcome to bikeshedding other words

Thanks for the issues on the main repo, glad to see more activity as we move towards beta-rust!
